### PR TITLE
fixes for scss and line numbers

### DIFF
--- a/styles/language.less
+++ b/styles/language.less
@@ -306,3 +306,21 @@
     color: inherit;
   }
 }
+
+//scss
+.support.constant.property-value.css, .support.constant.property-value.scss, .variable.scss {
+  color: @syntax-text-color;
+}
+
+.meta.property-list.scss
+.meta.property-list.scss
+.meta.property-value.scss
+.support.constant.property-value.scss {
+  color: @blue;
+}
+
+
+//css
+.support.constant.property-name.css, .support.type.property-name.css {
+  color: @blue;
+}

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -23,7 +23,7 @@
 @syntax-result-marker-color-selected: @syntax-base-accent-color;
 
 // Gutter colors
-@syntax-gutter-text-color: darken(@syntax-text-color, 26%);
+@syntax-gutter-text-color: #b7b7b7;
 @syntax-gutter-text-color-selected: @syntax-text-color;
 @syntax-gutter-background-color: @syntax-background-color; // unused
 @syntax-gutter-background-color-selected: lighten(@syntax-background-color, 2%);


### PR DESCRIPTION
Set the line numbers to match line numbers on github (they were much lighter)

SCSS property values and variables seem to be #333.  Example usage:

``` scss
align-items: stretch;
background-color: $pb-bg2;
```

However, SCSS values in a list ARE blue.  Example usage:

``` scss
border-right: 1px solid #e8e8e8;
```

of course, in this markdown reply, the colors are all black.
