### PR TITLE
Use white for editor background

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -6,7 +6,7 @@
 
 // Base colors -----------------------------------
 @syntax-base-accent-color:      hsl(220, 100%, 66%);
-@syntax-base-background-color:  @very-light-gray;
+@syntax-base-background-color:  #fff;
 @syntax-base-text-color:        @dark-gray;
 @syntax-comment-color:          @light-gray;
 @syntax-base-guide-color:       fade(@syntax-base-text-color, 15%);


### PR DESCRIPTION
GitHub uses white in their code preview, not light gray. Light gray is only inside of markdown code fences.
